### PR TITLE
Add note regarding the buildkite-agent version required

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,7 +2,7 @@
 
 [![Add to Buildkite](https://buildkite.com/button.svg)](https://buildkite.com/new)
 
-This example pipeline shows you how to annotate your builds with RSpec Junit error information and the `buildkite-agent annotate` CLI command.
+This example pipeline shows you how to annotate your builds with RSpec Junit error information and the `buildkite-agent annotate` CLI command (requires `buildkite-agent` v3.0-beta.23 or newer).
 
 ![Example](screenshot.png)
 


### PR DESCRIPTION
Alas, we can't use this on v2.x agents.
Making that obvious in the readme file.