### PR TITLE
Bump ruby to 3.x so that nokogiri installs 😬

### DIFF
--- a/.buildkite/junit.sh
+++ b/.buildkite/junit.sh
@@ -8,7 +8,8 @@ echo "--- :junit: Download the junits"
 buildkite-agent artifact download tmp/rspec-*.xml tmp
 
 echo "--- :junit::ruby: Processing the junits"
-docker run --rm -v "$(pwd):/app" ruby:2.4 bash -c "cd /app && gem install nokogiri --quiet --silent && ruby /app/.buildkite/lib/junit.rb /app/tmp/*.xml" > tmp/annotation.md
+docker run --rm -v "$(pwd):/app" ruby:3-slim \
+  bash -c "cd /app && gem install nokogiri --quiet --silent && ruby /app/.buildkite/lib/junit.rb /app/tmp/*.xml" > tmp/annotation.md
 
 echo "--- :buildkite: Creating annotation"
 buildkite-agent annotate --context junit --style error < tmp/annotation.md


### PR DESCRIPTION
Awkwardly this example is so old that nokogiri no longer installs:

```
ERROR:  Error installing nokogiri:
	The last version of nokogiri (>= 0) to support your Ruby & RubyGems was 1.10.10. Try installing it with `gem install nokogiri -v 1.10.10`
	nokogiri requires Ruby version >= 2.5, < 3.1.dev. The current ruby version is 2.4.10.364.
```

I could have found an old nokogiri I guess, but seemed easier to just bump ruby and everything works again.

