### PR TITLE
PB-677-rspec-image use image attribute

### DIFF
--- a/.buildkite/deploy.sh
+++ b/.buildkite/deploy.sh
@@ -1,1 +1,3 @@
+#!/bin/bash
+
 echo "Deploying project! 🚀"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,14 +10,16 @@ steps:
           image: "ruby:2.4"
           workdir: /app
 
-  - wait: ~
+  - wait:
     continue_on_failure: true
 
   - label: ":junit:"
     commands:
       - .buildkite/junit.sh
 
-  - wait
+  - wait:
+    continue_on_failure: true
 
-  - command: ".buildkite/deploy.sh"
-    label: ":rocket:"
+  - label: ":rocket:"
+    commands:
+      - .buildkite/deploy.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,4 @@
+image: "sorchaabel/ruby-pipeline-example:1.0"
 steps:
   - label: ":rspec:"
     artifact_paths: "tmp/rspec-*.xml"


### PR DESCRIPTION
Use new step `image` attribute to use docker hub image
For complete e2e it's using the public image `"sorchaabel/ruby-pipeline-example:1.0"` on dockerhub
I'll circle back in a few days and update this to use a buildkite official image.